### PR TITLE
Escape HTML tags in tkinter bind sequence

### DIFF
--- a/pistus/lab6-pistus.html
+++ b/pistus/lab6-pistus.html
@@ -57,7 +57,7 @@ CentraleSupélec associations. </p>
   <h2>Context and Objective</h2>
 
   <p>"Pistus" (short for "Piston Ski") is an event organised by <a href="http://wacs.fr" target="_blank">WACS (Winter
-      Association CentraleSupélec)</a> during
+      Association CentraleSupélec)</a> during
     the winter holidays every year. It's an awesome week-long mountain trip involving many
     activities (including skiing, snowboarding, raclette binges and parties, just
     to name a few).
@@ -1517,7 +1517,7 @@ We can define <TT>find_student</TT> <b>directly inside</b> the function <TT>crea
   <li class="exercise"> Copy the following code right after the definition of the text field <TT>student_number_entry</TT>.
 <pre class="line-numbers"><code class="language-python">def find_student(event):
     print("Here you'll write the code to find the student in the database", event.type)
-stud_number_entry.bind('<FocusOut>', find_student)</code></pre>
+stud_number_entry.bind('&#60;FocusOut&#62;', find_student)</code></pre>
 </ul>
 Lines 1-2 define the function <TT>find_student</TT>. 
 Line 3 tells the GUI to invoke the function <TT>find_student</TT> when the mouse cursor leaves ("focus out") the text field 
@@ -1698,7 +1698,7 @@ def get_edition(event):
     if row is not None:
         reg_fee_entry.insert(0, row[0])
         reg_fee_entry.configure(state = 'disabled')
-pistus_edition_entry.bind('<FocusOut>', get_edition)
+pistus_edition_entry.bind('&#60;FocusOut&#62;', get_edition)
 pistus_edition_entry.grid(row=0, column=1, padx=10, pady=10, sticky='W')
 
 ttk.Label(reg_tab, text="Registration fee *").grid(row=1, padx=10, pady=10, sticky='W')


### PR DESCRIPTION
Rationale:

<img width="982" alt="Screen Shot 2019-10-09 at 10 22 45" src="https://user-images.githubusercontent.com/8351433/66464180-c4338380-ea7e-11e9-9729-b70d5dff7ccb.png">

(fyi changes at line 60 and 1970 were auto-added by Github online editor, seems harmless though)